### PR TITLE
Fix #1, remove logging for status sets, and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Shortcake
+RPC for Strawberry Music Player.
+
+## Building
+ 1. Clone the repo with `git clone https://github.com/MechaDragonX/Shortcake.git`
+ 2. Open `Shortcake.sln` in Visual Studio
+ 3. Build using Ctrl-Shift-B or Build > Build Solution
+ 4. Build output is in `bin/Debug` or `bin/Release`, depending on what config you built for.
+
+## Usage
+ 1. Open Discord.
+ 2. Open `Shortcake.exe`.
+ 3. Status gets automatically set.

--- a/Strawberry.cs
+++ b/Strawberry.cs
@@ -73,17 +73,27 @@ namespace Shortcake
             string details;
             try
             {
-                if(!windowTitle.Contains(" - "))
-                    details = "Sifting through records";
-                else
-                    details = windowTitle;
+                switch (windowTitle)
+				{
+                    case "Strawberry Music Player":
+                    case "Equalizer":
+                    case "Cover Manager":
+                    case "Transcode Music":
+                    case "Settings":
+                        details = "Nothing playing.";
+                        break;
+                    default:
+                        details = windowTitle;
+                        break;
+                }
             }
             catch (Exception) { return; }
 
             string status;
             try
             {
-                status = "Listening to Music";
+                if (details != "Nothing playing.") status = "Listening to music";
+                else status = null;
             }
             catch(Exception) { return; }
 
@@ -100,11 +110,10 @@ namespace Shortcake
                         LargeImageText = "Strawberry"
                     }
                 });
-                Console.WriteLine("Presence successfully set!");
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                Console.WriteLine("Presence was not set successfully!");
+                Console.WriteLine($"Presence was not set successfully.\nERROR: ${e.Message}");
                 return;
             }
         }


### PR DESCRIPTION
It now checks window title for known menus. If the title is not in a known menu or idle (`Strawberry Music Player`), sets details to the window title. Also, it no longer prints every time the status is set.
Oh, and a basic README.md was added.

P.S. you saved me from having to write this RPC on my own, thanks 😅